### PR TITLE
refactor(amipy): refactored repo so that it can be installed with pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,63 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+MANIFEST
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# shell stuff
+#*.sh
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.idea/
+
+# ignore all .ipynb_checkpoints
+.ipynb_checkpoints
+
+

--- a/amipy/__init__.py
+++ b/amipy/__init__.py
@@ -1,0 +1,9 @@
+__name__ = 'amipy'
+__author__ = 'Martijn Russcher'
+
+# imports
+from .version import __version__
+
+# imports
+from .ami import Ami
+from .amiwrapper import AmiWrapper

--- a/amipy/ami.py
+++ b/amipy/ami.py
@@ -1,31 +1,35 @@
 from abc import abstractmethod
 from bmipy import Bmi
 
+
 class Ami(Bmi):
-    """This class extends the CSDMS Basic Model Interface
+    """
+    This class extends the CSDMS Basic Model Interface
 
     The extension to the BMI is twofold:
 
-    - the model's outer convergence loop is exposed to facilitate coupling at this level
+    - the model's outer convergence loop is exposed to facilitate coupling at
+      this level
 
-    - a model can have sub-components which share the time stepping but have their own convergence loop
+    - a model can have sub-components which share the time stepping but have
+      their own convergence loop
 
-    It does not change anything in the BMI interface, so models implementing the AMI interface are
-    compatible with BMI
+    It does not change anything in the BMI interface, so models implementing
+    the AMI interface are compatible with BMI
 
     """
 
     @abstractmethod
     def prepare_timestep(self) -> None:
         """
-        
+
         """
         ...
-        
+
     @abstractmethod
     def finalize_timestep(self) -> None:
         """
-        
+
         """
         ...
 

--- a/amipy/amiwrapper.py
+++ b/amipy/amiwrapper.py
@@ -2,15 +2,17 @@ import numpy as np
 from ctypes import *
 from typing import Tuple
 
-from numpy.ctypeslib import ndpointer
-
-from ami import Ami
+from .ami import Ami
 
 BMI_SUCCESS = 0
 BMI_FAILURE = 1
 
+
 class AmiWrapper(Ami):
-    """This is the AMI (BMI++) wrapper for marshalling python types into the kernels, and v.v."""
+    """
+    This is the AMI (BMI++) wrapper for marshalling python types into
+    the kernels, and v.v.
+    """
 
     def __init__(self, path):
         self.path = path
@@ -35,12 +37,14 @@ class AmiWrapper(Ami):
 
     def get_current_time(self) -> float:
         current_time = c_double(0.0)
-        check_result(self.dll.get_current_time(byref(current_time)), "get_current_time")
+        check_result(self.dll.get_current_time(byref(current_time)),
+                     "get_current_time")
         return current_time.value
 
     def get_start_time(self) -> float:
         start_time = c_double(0.0)
-        check_result(self.dll.get_start_time(byref(start_time)), "get_start_time")
+        check_result(self.dll.get_start_time(byref(start_time)),
+                     "get_start_time")
         return start_time.value
 
     def get_end_time(self) -> float:
@@ -68,19 +72,25 @@ class AmiWrapper(Ami):
 
     def get_var_type(self, name: str) -> str:
         var_type = create_string_buffer(self.MAXSTRLEN)
-        check_result(self.dll.get_var_type(c_char_p(name.encode()), byref(var_type)), "get_var_type", "for variable " + name)
+        check_result(
+            self.dll.get_var_type(c_char_p(name.encode()), byref(var_type)),
+            "get_var_type", "for variable " + name)
         return var_type.value.decode()
 
     # strictly speaking not BMI...
     def get_var_shape(self, name: str) -> np.ndarray:
         rank = self.get_var_rank(name)
         array = np.zeros(rank, dtype=np.int)
-        check_result(self.dll.get_var_shape(c_char_p(name.encode()), c_void_p(array.ctypes.data)), "get_var_shape", "for variable " + name)
+        check_result(self.dll.get_var_shape(c_char_p(name.encode()),
+                                            c_void_p(array.ctypes.data)),
+                     "get_var_shape", "for variable " + name)
         return array
 
     def get_var_rank(self, name: str) -> int:
         rank = c_int(0)
-        check_result(self.dll.get_var_rank(c_char_p(name.encode()), byref(rank)), "get_var_rank", "for variable " + name)
+        check_result(
+            self.dll.get_var_rank(c_char_p(name.encode()), byref(rank)),
+            "get_var_rank", "for variable " + name)
         return rank.value
 
     def get_var_units(self, name: str) -> str:
@@ -88,12 +98,16 @@ class AmiWrapper(Ami):
 
     def get_var_itemsize(self, name: str) -> int:
         item_size = c_int(0)
-        check_result(self.dll.get_var_itemsize(c_char_p(name.encode()), byref(item_size)), "get_var_itemsize", "for variable " + name)
+        check_result(self.dll.get_var_itemsize(c_char_p(name.encode()),
+                                               byref(item_size)),
+                     "get_var_itemsize", "for variable " + name)
         return item_size.value
 
     def get_var_nbytes(self, name: str) -> int:
         nbytes = c_int(0)
-        check_result(self.dll.get_var_nbytes(c_char_p(name.encode()), byref(nbytes)), "get_var_nbytes", "for variable " + name)
+        check_result(
+            self.dll.get_var_nbytes(c_char_p(name.encode()), byref(nbytes)),
+            "get_var_nbytes", "for variable " + name)
         return nbytes.value
 
     def get_var_location(self, name: str) -> str:
@@ -112,9 +126,8 @@ class AmiWrapper(Ami):
 
         # first scalars
         rank = self.get_var_rank(name)
-        if (rank == 0):
+        if rank == 0:
             return self.get_value_ptr_scalar(name)
-
 
         vartype = self.get_var_type(name)
         shape_array = self.get_var_shape(name)
@@ -124,14 +137,20 @@ class AmiWrapper(Ami):
         ndim = len(shape_tuple)
 
         if vartype.startswith("DOUBLE"):
-            arraytype = np.ctypeslib.ndpointer(dtype="double", ndim=ndim, shape=shape_tuple, flags='F')
+            arraytype = np.ctypeslib.ndpointer(dtype="double", ndim=ndim,
+                                               shape=shape_tuple, flags='F')
             values = arraytype()
-            check_result(self.dll.get_value_ptr_double(c_char_p(name.encode()), byref(values)), "get_value_ptr", "for variable " + name)
+            check_result(self.dll.get_value_ptr_double(c_char_p(name.encode()),
+                                                       byref(values)),
+                         "get_value_ptr", "for variable " + name)
             return values.contents
         elif vartype.startswith("INTEGER"):
-            arraytype = np.ctypeslib.ndpointer(dtype="int", ndim=ndim, shape=shape_tuple, flags='F')
+            arraytype = np.ctypeslib.ndpointer(dtype="int", ndim=ndim,
+                                               shape=shape_tuple, flags='F')
             values = arraytype()
-            check_result(self.dll.get_value_ptr_int(c_char_p(name.encode()), byref(values)), "get_value_ptr", "for variable " + name)
+            check_result(self.dll.get_value_ptr_int(c_char_p(name.encode()),
+                                                    byref(values)),
+                         "get_value_ptr", "for variable " + name)
             return values.contents
 
     def get_value_ptr_scalar(self, name: str) -> np.ndarray:
@@ -139,20 +158,23 @@ class AmiWrapper(Ami):
         if vartype.startswith("DOUBLE"):
             assert False
         elif vartype.startswith("INTEGER"):
-            arraytype = np.ctypeslib.ndpointer(dtype="int", ndim=1, shape=(1,), flags='F')
+            arraytype = np.ctypeslib.ndpointer(dtype="int", ndim=1, shape=(1,),
+                                               flags='F')
             values = arraytype()
-            check_result(self.dll.get_value_ptr_int(c_char_p(name.encode()), byref(values)), "get_value_ptr", "for variable " + name)
+            check_result(self.dll.get_value_ptr_int(c_char_p(name.encode()),
+                                                    byref(values)),
+                         "get_value_ptr", "for variable " + name)
             return values.contents
 
-
-
-    def get_value_at_indices(self, name: str, dest: np.ndarray, inds: np.ndarray) -> np.ndarray:
+    def get_value_at_indices(self, name: str, dest: np.ndarray,
+                             inds: np.ndarray) -> np.ndarray:
         pass
 
     def set_value(self, name: str, values: np.ndarray) -> None:
         pass
 
-    def set_value_at_indices(self, name: str, inds: np.ndarray, src: np.ndarray) -> None:
+    def set_value_at_indices(self, name: str, inds: np.ndarray,
+                             src: np.ndarray) -> None:
         pass
 
     def get_grid_rank(self, grid: int) -> int:
@@ -191,16 +213,20 @@ class AmiWrapper(Ami):
     def get_grid_face_count(self, grid: int) -> int:
         pass
 
-    def get_grid_edge_nodes(self, grid: int, edge_nodes: np.ndarray) -> np.ndarray:
+    def get_grid_edge_nodes(self, grid: int,
+                            edge_nodes: np.ndarray) -> np.ndarray:
         pass
 
-    def get_grid_face_edges(self, grid: int, face_edges: np.ndarray) -> np.ndarray:
+    def get_grid_face_edges(self, grid: int,
+                            face_edges: np.ndarray) -> np.ndarray:
         pass
 
-    def get_grid_face_nodes(self, grid: int, face_nodes: np.ndarray) -> np.ndarray:
+    def get_grid_face_nodes(self, grid: int,
+                            face_nodes: np.ndarray) -> np.ndarray:
         pass
 
-    def get_grid_nodes_per_face(self, grid: int, nodes_per_face: np.ndarray) -> np.ndarray:
+    def get_grid_nodes_per_face(self, grid: int,
+                                nodes_per_face: np.ndarray) -> np.ndarray:
         pass
 
     # ===========================
@@ -214,27 +240,33 @@ class AmiWrapper(Ami):
 
     def get_subcomponent_count(self) -> int:
         count = c_int(0)
-        check_result(self.dll.get_subcomponent_count(byref(count)), "get_subcomponent_count")
+        check_result(self.dll.get_subcomponent_count(byref(count)),
+                     "get_subcomponent_count")
         return count.value
 
     def prepare_iteration(self, component_id) -> None:
         cid = c_int(component_id)
-        check_result(self.dll.prepare_iteration(byref(cid)), "prepare_iteration")
+        check_result(self.dll.prepare_iteration(byref(cid)),
+                     "prepare_iteration")
 
     def do_iteration(self, component_id) -> bool:
         cid = c_int(component_id)
         has_converged = c_int(0)
-        check_result(self.dll.do_iteration(byref(cid), byref(has_converged)), "do_iteration")
+        check_result(self.dll.do_iteration(byref(cid), byref(has_converged)),
+                     "do_iteration")
         return has_converged.value == 1
 
     def finalize_iteration(self, component_id) -> None:
         cid = c_int(component_id)
-        check_result(self.dll.finalize_iteration(byref(cid)), "finalize_iteration")
+        check_result(self.dll.finalize_iteration(byref(cid)),
+                     "finalize_iteration")
 
 
-
-
-def check_result(result, function_name, detail = ""):
-    """Utility function to check the BMI status in the kernel"""
+def check_result(result, function_name, detail=""):
+    """
+    Utility function to check the BMI status in the kernel
+    """
     if result != BMI_SUCCESS:
-        raise Exception("MODFLOW 6 BMI, exception in: " + function_name + "(" + detail + ")")
+        msg = "MODFLOW 6 BMI, exception in: " + function_name + \
+              "(" + detail + ")"
+        raise Exception(msg)

--- a/amipy/version.py
+++ b/amipy/version.py
@@ -1,0 +1,5 @@
+# amipy version file
+major = 0
+minor = 1
+micro = 0
+__version__ = '{:d}.{:d}.{:d}'.format(major, minor, micro)

--- a/examples/run.py
+++ b/examples/run.py
@@ -2,7 +2,7 @@ import os
 import sys
 import getopt
 
-from amiwrapper import AmiWrapper
+from amipy import AmiWrapper
 
 # defaults
 mf6_dll = r"d:\checkouts\modflow6-mjr\msvs\dll\x64\Debug\mf6.dll"

--- a/examples/run_advanced.py
+++ b/examples/run_advanced.py
@@ -4,7 +4,7 @@ from math import sin
 import numpy as np
 
 import matplotlib.pyplot as plt
-from amiwrapper import AmiWrapper
+from amipy import AmiWrapper
 
 # for debugging
 print("PID: ", os.getpid(), "; continue? [y]")

--- a/examples/run_anisotropy.py
+++ b/examples/run_anisotropy.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 
 import matplotlib.pyplot as plt
-from amiwrapper import AmiWrapper
+from amipy import AmiWrapper
 
 # for debugging
 print("PID: ", os.getpid(), "; continue? [y]")

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+import sys
+from setuptools import setup
+
+from amipy import __version__, __name__, __author__
+
+
+# ensure minimum version of Python is running
+if sys.version_info[0:2] < (3, 6):
+    raise RuntimeError('amipy requires Python >= 3.6')
+
+
+setup(name=__name__,
+      description='amipy is a extension to the pybmi Python package .',
+      long_description='amipy is a extension to the pybmi Python package ' +
+                       'for MODFLOW 6 and other codes.',
+      author=__author__,
+      author_email='Martijn.Russcher@deltares.nl',
+      url='https://github.com/mjr-deltares/modflow6-bmipy.git',
+      license='New BSD',
+      platforms='Windows, Mac OS-X, Linux',
+      install_requires=['bmipy', 'numpy'],
+      packages=[__name__],
+      include_package_data=True,
+      version=__version__,
+      classifiers=['Topic :: Scientific/Engineering :: Hydrology'])


### PR DESCRIPTION
Rename package amipy to be consistent with bmipy naming. Refactor
line lengths to PEP8 standard. Add 'version.py', '\_\_init\_\_.py', and 'setup.py'
files. All source files are in the amipy directory and all other
existing repo files have been moved to the examples subdirectory.
Updated import statement in the example files. The new import statement
is:

	from amipy import AmiWrapper

or:

	import amipy

then

	mf6 = amipy.AmiWrapper(exe)