### PR TITLE
Fix setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,5 @@ docs/_build/
 # ignore all .ipynb_checkpoints
 .ipynb_checkpoints
 
-
+# Visual Studio Code
+.vscode/

--- a/amipy/__init__.py
+++ b/amipy/__init__.py
@@ -1,9 +1,3 @@
-__name__ = 'amipy'
-__author__ = 'Martijn Russcher'
-
-# imports
-from .version import __version__
-
 # imports
 from .ami import Ami
 from .amiwrapper import AmiWrapper

--- a/amipy/version.py
+++ b/amipy/version.py
@@ -1,5 +1,0 @@
-# amipy version file
-major = 0
-minor = 1
-micro = 0
-__version__ = '{:d}.{:d}.{:d}'.format(major, minor, micro)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 import sys
 from setuptools import setup
 
-from amipy import __version__, __name__, __author__
-
+__version__ = "0.1.0"
+__name__ = 'amipy'
+__author__ = 'Martijn Russcher'
 
 # ensure minimum version of Python is running
 if sys.version_info[0:2] < (3, 6):


### PR DESCRIPTION
Currently install via pip fails when bmipy is not installed.
This commit removes import of amipy in setup.py
and moves version and name strings into setup.py